### PR TITLE
improve script tests

### DIFF
--- a/script/patch/apply-patches-test.bats
+++ b/script/patch/apply-patches-test.bats
@@ -1,16 +1,7 @@
 #!/bin/bash
 load "../../test/test-util.sh"
-load "./patch-util.sh"
 
 SCRIPT_UNDER_TEST="$BATS_TEST_DIRNAME/apply-patches.sh"
-
-setup() {
-  TEST_TEMP_DIR="$(temp_make)"
-}
-
-teardown() {
-  temp_del "$TEST_TEMP_DIR"
-}
 
 @test "main | usage" {
   run "$SCRIPT_UNDER_TEST"
@@ -19,36 +10,10 @@ teardown() {
 }
 
 @test "main | apply patches" {
-  cp -r "$TEST_RESOURCES_DIRECTORY/patch/apply-patches/." "$TEST_TEMP_DIR"
-
-  cd "$TEST_TEMP_DIR"
-  run "$SCRIPT_UNDER_TEST" "$TEST_TEMP_DIR"
+  run_script_with_mocked_commands -s "$SCRIPT_UNDER_TEST" -a "path" -m "source" -m "require_sudo" -m "run_and_log"
   assert_success
 
-  assert_line_log 0 "INFO" "Searching for files named '$FILES_TO_PATCH_NAME' in '$TEST_TEMP_DIR'."
-  assert_line_log 1 "INFO" "Applying patches to files in '$TEST_TEMP_DIR/files-to-patch'."
-
-  assert_file_count "$TEST_TEMP_DIR" 2
-  local file
-  file="$(find "$TEST_TEMP_DIR" -mindepth 1 -maxdepth 1 -type f -name "*.log")"
-  assert_file_log_name "$file" "apply-patches"
-}
-
-@test "main | require sudo" {
-  cd "$TEST_TEMP_DIR"
-  run bash -c "sudo() {
-  if [[ \"\$1\" == \"-n\" && \"\$2\" == \"true\" ]]; then
-    return 1
-  fi
-  if [[ \"\$1\" == \"-v\" ]]; then
-    return 0
-  fi
-  printf \"Unexpected arguments for 'sudo': %s\" \"\$*\"
-  exit 255
-}
-source $SCRIPT_UNDER_TEST $TEST_TEMP_DIR"
-  assert_success
-
-  assert_line -n 0 "This script requires root privileges. Please authenticate."
-  assert_line_log 1 "INFO" "Searching for files named '$FILES_TO_PATCH_NAME' in '$TEST_TEMP_DIR'."
+  assert_output "MOCK: source \"./../script-util.sh\"
+MOCK: require_sudo
+MOCK: run_and_log \"apply_patches path\""
 }

--- a/script/patch/revert-patches-test.bats
+++ b/script/patch/revert-patches-test.bats
@@ -1,16 +1,7 @@
 #!/bin/bash
 load "../../test/test-util.sh"
-load "./patch-util.sh"
 
 SCRIPT_UNDER_TEST="$BATS_TEST_DIRNAME/revert-patches.sh"
-
-setup() {
-  TEST_TEMP_DIR="$(temp_make)"
-}
-
-teardown() {
-  temp_del "$TEST_TEMP_DIR"
-}
 
 @test "main | usage" {
   run "$SCRIPT_UNDER_TEST"
@@ -19,36 +10,10 @@ teardown() {
 }
 
 @test "main | revert patches" {
-  cp -r "$TEST_RESOURCES_DIRECTORY/patch/revert-patches/." "$TEST_TEMP_DIR"
-
-  cd "$TEST_TEMP_DIR"
-  run "$SCRIPT_UNDER_TEST" "$TEST_TEMP_DIR"
+  run_script_with_mocked_commands -s "$SCRIPT_UNDER_TEST" -a "path" -m "source" -m "require_sudo" -m "run_and_log"
   assert_success
 
-  assert_line_log 0 "INFO" "Searching for files named '$FILES_TO_PATCH_NAME' in '$TEST_TEMP_DIR'."
-  assert_line_log 1 "INFO" "Reverting patches of files in '$TEST_TEMP_DIR/files-to-patch'."
-
-  assert_file_count "$TEST_TEMP_DIR" 2
-  local file
-  file="$(find "$TEST_TEMP_DIR" -mindepth 1 -maxdepth 1 -type f -name "*.log")"
-  assert_file_log_name "$file" "revert-patches"
-}
-
-@test "main | require sudo" {
-  cd "$TEST_TEMP_DIR"
-  run bash -c "sudo() {
-  if [[ \"\$1\" == \"-n\" && \"\$2\" == \"true\" ]]; then
-    return 1
-  fi
-  if [[ \"\$1\" == \"-v\" ]]; then
-    return 0
-  fi
-  printf \"Unexpected arguments for 'sudo': %s\" \"\$*\"
-  exit 255
-}
-source $SCRIPT_UNDER_TEST $TEST_TEMP_DIR"
-  assert_success
-
-  assert_line -n 0 "This script requires root privileges. Please authenticate."
-  assert_line_log 1 "INFO" "Searching for files named '$FILES_TO_PATCH_NAME' in '$TEST_TEMP_DIR'."
+  assert_output "MOCK: source \"./../script-util.sh\"
+MOCK: require_sudo
+MOCK: run_and_log \"revert_patches path\""
 }

--- a/setup/debian/mint/cinnamon/install/common/install-test.bats
+++ b/setup/debian/mint/cinnamon/install/common/install-test.bats
@@ -2,7 +2,7 @@
 load "../../../../../../test/test-util.sh"
 
 @test "install" {
-  run_script_with_mocked_commands "$BATS_TEST_DIRNAME/install.sh" "source" "apply_patches"
+  run_script_with_mocked_commands -s "$BATS_TEST_DIRNAME/install.sh" -m "source" -m "apply_patches"
   assert_success
 
   assert_output "MOCK: source \"./../../../../../../script/script-util.sh\"

--- a/test/util/run.sh
+++ b/test/util/run.sh
@@ -1,7 +1,20 @@
 #!/bin/bash
 run_script_with_mocked_commands() {
-  local script="$1"
-  local -a commands_to_mock=("${@:2}")
+  local script
+  local -a script_arguments
+  local -a commands_to_mock
+
+  while getopts ":a:m:s:" "opt"; do
+    case "$opt" in
+      a) script_arguments+=("$OPTARG") ;;
+      m) commands_to_mock+=("$OPTARG") ;;
+      s) script="$OPTARG" ;;
+      *)
+        printf "Invalid option '-%s' for command '%s'" "$OPTARG" "run_script_with_mocked_commands" >&2
+        exit 2
+        ;;
+    esac
+  done
 
   local run_command=""
   for command in "${commands_to_mock[@]}"; do
@@ -16,7 +29,7 @@ run_script_with_mocked_commands() {
 "
   done
   run_command+="eval \"\$(cat \"$script\")\""
-  run bash -c "$run_command"
+  run bash -c "$run_command" "$script" "${script_arguments[@]}"
 
   return 0
 }


### PR DESCRIPTION
- Allow providing arguments to the script executed by `run_script_with_mocked_commands`.
- Use `run_script_with_mocked_commands` for testing `apply-patches.sh` and `revert-patches.sh`.
